### PR TITLE
Update README.md installation for Arch Linux 

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ https://writer.drakeet.com/desktop
 
 https://github.com/purewriter/desktop/releases
 
+### Arch Linux 
+
+Arch Linux 或者 基于Arch的发行版 (Manjaro 等), 可以使用 AUR Helper 从[AUR](https://aur.archlinux.org/packages/purewriter-desktop/) 安装
+
+例如,使用 `yay` 从 AUR 安装 `purewriter-desktop`
+
+```
+yay -S purewriter-desktop # 从源码构建的版本
+
+yay -S purewriter         # liaronce 第三方编译构建的版本
+```
+
 ### 第三方编译版本
 
 第三方编译的 Linux & Windows **x86(32 位)** 版本


### PR DESCRIPTION
我把 `purewriter` 打包到了AUR, 测试可以正常使用.  AUR 是 Arch Linux 的用户软件仓库 ; 对于使用 Arch Linux 或者基于Arch 的发行版 的用户, 可以 简单直接从 `AUR` 安装. 